### PR TITLE
Replace underscore with dash

### DIFF
--- a/theme-base/components/button/_button.scss
+++ b/theme-base/components/button/_button.scss
@@ -155,7 +155,7 @@ body {
     }
 
     .ui-icon-triangle-1-s {
-      @include icon_override("\e902");
+      @include icon-override("\e902");
     }
   }
 

--- a/theme-base/components/button/_splitbutton.scss
+++ b/theme-base/components/button/_splitbutton.scss
@@ -31,7 +31,7 @@ body {
       border-bottom-right-radius: $borderRadius;
 
       .ui-icon.ui-icon-triangle-1-s {
-        @include icon_override("\e902");
+        @include icon-override("\e902");
       }
     }
   }
@@ -51,7 +51,7 @@ body {
       }
 
       .ui-icon {
-        @include icon_override("\e908");
+        @include icon-override("\e908");
         position: absolute;
         left: nth($inputListHeaderPadding, 2) + nth($inputPadding, 2);
         top: 50%;

--- a/theme-base/components/data/_datatable.scss
+++ b/theme-base/components/data/_datatable.scss
@@ -62,17 +62,17 @@ body {
           margin: 0 0 0 $inlineSpacing;
 
           &.ui-icon-carat-2-n-s {
-            @include icon_override('\e99e');
+            @include icon-override('\e99e');
             vertical-align: middle;
           }
 
           &.ui-icon-triangle-1-n {
-            @include icon_override('\e99f');
+            @include icon-override('\e99f');
             vertical-align: middle;
           }
 
           &.ui-icon-triangle-1-s {
-            @include icon_override('\e9a0');
+            @include icon-override('\e9a0');
             vertical-align: middle;
           }
         }
@@ -175,15 +175,15 @@ body {
 
           .ui-icon {
             &.ui-icon-pencil {
-              @include icon_override('\e942');
+              @include icon-override('\e942');
             }
 
             &.ui-icon-check {
-              @include icon_override('\e909');
+              @include icon-override('\e909');
             }
 
             &.ui-icon-close {
-              @include icon_override('\e90b');
+              @include icon-override('\e90b');
             }
           }
         }
@@ -192,11 +192,11 @@ body {
           @include action-icon();
 
           &.ui-icon-circle-triangle-e {
-            @include icon_override('\e901');
+            @include icon-override('\e901');
           }
 
           &.ui-icon-circle-triangle-s {
-            @include icon_override('\e902');
+            @include icon-override('\e902');
           }
         }
 
@@ -207,11 +207,11 @@ body {
             @include action-icon();
 
             &.ui-icon-circle-triangle-e {
-              @include icon_override('\e901');
+              @include icon-override('\e901');
             }
 
             &.ui-icon-circle-triangle-s {
-              @include icon_override('\e902');
+              @include icon-override('\e902');
             }
           }
         }
@@ -240,12 +240,12 @@ body {
     }
 
     > .ui-icon-arrowthick-1-s {
-      @include icon_override('\e919');
+      @include icon-override('\e919');
       display: none !important;
     }
 
     > .ui-icon-arrowthick-1-n {
-      @include icon_override('\e91c');
+      @include icon-override('\e91c');
       padding-top: 1.5rem !important;
     }
 

--- a/theme-base/components/data/_picklist.scss
+++ b/theme-base/components/data/_picklist.scss
@@ -59,7 +59,7 @@ body {
       }
 
       .ui-icon {
-        @include icon_override("\e908");
+        @include icon-override("\e908");
         position: absolute;
         left: nth($inputPadding, 2);
         top: 50%;

--- a/theme-base/components/data/_timeline.scss
+++ b/theme-base/components/data/_timeline.scss
@@ -9,19 +9,19 @@ body {
 
       .ui-icon {
         &.ui-icon-circle-zoomin {
-          @include icon_override("\e98f");
+          @include icon-override("\e98f");
         }
 
         &.ui-icon-circle-zoomout {
-          @include icon_override("\e990");
+          @include icon-override("\e990");
         }
 
         &.ui-icon-circle-arrow-w {
-          @include icon_override("\e91f");
+          @include icon-override("\e91f");
         }
 
         &.ui-icon-circle-arrow-e {
-          @include icon_override("\e920");
+          @include icon-override("\e920");
         }
       }
     }

--- a/theme-base/components/data/_tree.scss
+++ b/theme-base/components/data/_tree.scss
@@ -26,15 +26,15 @@ body {
             @include action-icon();
 
             &.ui-icon-triangle-1-e {
-              @include icon_override("\e901");
+              @include icon-override("\e901");
             }
 
             &.ui-icon-triangle-1-s {
-              @include icon_override("\e902");
+              @include icon-override("\e902");
             }
 
             &.ui-icon-triangle-1-w {
-              @include icon_override("\e900");
+              @include icon-override("\e900");
             }
           }
 
@@ -68,7 +68,7 @@ body {
             margin-right: $inlineSpacing * 2;
 
             .ui-icon-minus {
-              @include icon_override("\e90f");
+              @include icon-override("\e90f");
               color: $panelContentTextColor;
             }
           }
@@ -132,11 +132,11 @@ body {
           vertical-align: middle;
 
           &.ui-icon-minus {
-            @include icon_override("\e90f");
+            @include icon-override("\e90f");
           }
 
           &.ui-icon-plus {
-            @include icon_override("\e90d");
+            @include icon-override("\e90d");
           }
         }
 
@@ -154,7 +154,7 @@ body {
           margin-right: $inlineSpacing;
 
           .ui-icon-minus {
-            @include icon_override("\e90f");
+            @include icon-override("\e90f");
             color: $panelContentTextColor;
           }
         }
@@ -169,7 +169,7 @@ body {
       margin: 0 0 $inlineSpacing 0;
 
       .ui-icon {
-        @include icon_override("\e908");
+        @include icon-override("\e908");
         position: absolute;
         left: nth($inputPadding, 2);
         top: 50%;

--- a/theme-base/components/data/_treetable.scss
+++ b/theme-base/components/data/_treetable.scss
@@ -60,17 +60,17 @@ body {
           margin: 0 0 0 $inlineSpacing;
 
           &.ui-icon-carat-2-n-s {
-            @include icon_override('\e99e');
+            @include icon-override('\e99e');
             vertical-align: middle;
           }
 
           &.ui-icon-triangle-1-n {
-            @include icon_override('\e99f');
+            @include icon-override('\e99f');
             vertical-align: middle;
           }
 
           &.ui-icon-triangle-1-s {
-            @include icon_override('\e9a0');
+            @include icon-override('\e9a0');
             vertical-align: middle;
           }
         }
@@ -127,11 +127,11 @@ body {
             @include action-icon();
 
             &.ui-icon-triangle-1-e {
-              @include icon_override("\e901");
+              @include icon-override("\e901");
             }
 
             &.ui-icon-triangle-1-s {
-              @include icon_override("\e902");
+              @include icon-override("\e902");
             }
           }
 
@@ -140,7 +140,7 @@ body {
             margin-right: $inlineSpacing * 2;
 
             .ui-icon-minus {
-              @include icon_override("\e90f");
+              @include icon-override("\e90f");
               color: $panelContentTextColor;
             }
           }
@@ -170,16 +170,16 @@ body {
             @include action-icon();
 
             &.ui-icon-pencil {
-              @include icon_override('\e942');
+              @include icon-override('\e942');
             }
 
             &.ui-icon-check {
-              @include icon_override('\e909');
+              @include icon-override('\e909');
               margin-right: $inlineSpacing;
             }
 
             &.ui-icon-close {
-              @include icon_override('\e90b');
+              @include icon-override('\e90b');
             }
           }
 

--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -28,7 +28,7 @@ body {
 
       .ui-fileupload-cancel {
         .ui-icon {
-          @include icon_override ("\e90b");
+          @include icon-override ("\e90b");
         }
       }
 
@@ -42,7 +42,7 @@ body {
 
   .ui-fileupload-simple {
     .ui-icon-plusthick {
-      @include icon_override ("\e90d");
+      @include icon-override ("\e90d");
     }
   }
 

--- a/theme-base/components/input/_autocomplete.scss
+++ b/theme-base/components/input/_autocomplete.scss
@@ -55,7 +55,7 @@ body {
         .ui-autocomplete-token-icon {
           margin-top: math.div(-1 * $iconSize, 2);
           position: absolute;
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
       }
 

--- a/theme-base/components/input/_checkbox.scss
+++ b/theme-base/components/input/_checkbox.scss
@@ -51,11 +51,11 @@ body {
         margin-top: math.div(-1 * $iconSize, 2);
 
         &.ui-icon-check {
-          @include icon_override("\e909");
+          @include icon-override("\e909");
         }
 
         &.ui-icon-closethick {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
       }
     }

--- a/theme-base/components/input/_chips.scss
+++ b/theme-base/components/input/_chips.scss
@@ -17,7 +17,7 @@ body {
         .ui-chips-token-icon {
           margin-top: math.div(-1 * $iconSize, 2);
           position: absolute;
-          @include icon_override("\e90c");
+          @include icon-override("\e90c");
         }
       }
 

--- a/theme-base/components/input/_datepicker.scss
+++ b/theme-base/components/input/_datepicker.scss
@@ -20,12 +20,12 @@ body {
     }
 
     .ui-datepicker-next {
-      @include icon_override("\e901");
+      @include icon-override("\e901");
       right: 0;
     }
 
     .ui-datepicker-prev {
-      @include icon_override("\e900");
+      @include icon-override("\e900");
       left: 0;
     }
 
@@ -237,7 +237,7 @@ body {
       @include action-icon();
 
       .ui-icon {
-        @include icon_override("\e903");
+        @include icon-override("\e903");
       }
     }
 
@@ -245,7 +245,7 @@ body {
       @include action-icon();
 
       .ui-icon {
-        @include icon_override("\e902");
+        @include icon-override("\e902");
       }
     }
 
@@ -260,7 +260,7 @@ body {
       @include border-radius-left(0);
 
       .ui-icon-calendar {
-        @include icon_override("\e927");
+        @include icon-override("\e927");
       }
     }
 

--- a/theme-base/components/input/_inplace.scss
+++ b/theme-base/components/input/_inplace.scss
@@ -17,14 +17,14 @@ body {
 
     .ui-inplace-save {
       .ui-icon {
-        @include icon_override("\e909");
+        @include icon-override("\e909");
       }
     }
 
     .ui-inplace-cancel {
       margin-left: math.div($inlineSpacing, 2);
       .ui-icon {
-        @include icon_override("\e90b");
+        @include icon-override("\e90b");
       }
     }
 

--- a/theme-base/components/input/_password.scss
+++ b/theme-base/components/input/_password.scss
@@ -6,13 +6,13 @@ body {
 
     &.ui-password-masked {
       .ui-password-icon {
-        @include icon_override ("\e966");
+        @include icon-override ("\e966");
       }
     }
 
     &.ui-password-unmasked {
       .ui-password-icon {
-        @include icon_override ("\e965");
+        @include icon-override ("\e965");
       }
     }
   }

--- a/theme-base/components/input/_rating.scss
+++ b/theme-base/components/input/_rating.scss
@@ -11,7 +11,7 @@ body {
       }
 
       a {
-        @include icon_override("\e90c");
+        @include icon-override("\e90c");
         text-indent: 0;
         transition: $transition;
         display: block;
@@ -38,7 +38,7 @@ body {
       }
 
       a {
-        @include icon_override("\e937");
+        @include icon-override("\e937");
         text-indent: 0;
         display: block;
         font-size: $ratingIconFontSize;
@@ -55,7 +55,7 @@ body {
 
     .ui-rating-star-on {
       a {
-        @include icon_override("\e936");
+        @include icon-override("\e936");
         display: block;
         font-size: $ratingIconFontSize;
         height: $ratingIconHeight;

--- a/theme-base/components/input/_selectcheckboxmenu.scss
+++ b/theme-base/components/input/_selectcheckboxmenu.scss
@@ -38,7 +38,7 @@ body {
         position: static;
         margin: 0;
         color: $inputIconColor;
-        @include icon_override("\e902");
+        @include icon-override("\e902");
       }
     }
 
@@ -74,7 +74,7 @@ body {
         .ui-selectcheckboxmenu-token-icon {
           margin-top: math.div(-1 * $iconSize, 2);
           position: absolute;
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
       }
 
@@ -142,7 +142,7 @@ body {
         }
 
         .ui-icon {
-          @include icon_override("\e908");
+          @include icon-override("\e908");
           position: absolute;
           left: nth($inputPadding, 2);
           top: 50%;
@@ -160,7 +160,7 @@ body {
         margin-right: 0;
 
         .ui-icon {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
           float: none;
         }
       }

--- a/theme-base/components/input/_selectonelistbox.scss
+++ b/theme-base/components/input/_selectonelistbox.scss
@@ -23,7 +23,7 @@ body {
       }
 
       .ui-icon {
-        @include icon_override("\e908");
+        @include icon-override("\e908");
         position: absolute;
         left: nth($inputListHeaderPadding, 2) + nth($inputPadding, 2);
         top: 50%;

--- a/theme-base/components/input/_selectonemenu.scss
+++ b/theme-base/components/input/_selectonemenu.scss
@@ -33,7 +33,7 @@ body {
         position: static;
         margin: 0;
         color: $inputIconColor;
-        @include icon_override("\e902");
+        @include icon-override("\e902");
       }
     }
 
@@ -98,7 +98,7 @@ body {
       }
 
       .ui-icon {
-        @include icon_override("\e908");
+        @include icon-override("\e908");
         position: absolute;
         left: nth($inputListHeaderPadding, 2) + nth($inputPadding, 2);
         top: 50%;

--- a/theme-base/components/input/_spinner.scss
+++ b/theme-base/components/input/_spinner.scss
@@ -22,7 +22,7 @@ body {
         border-top-right-radius: $borderRadius;
 
         .ui-icon-triangle-1-n {
-          @include icon_override ("\e933");
+          @include icon-override ("\e933");
         }
       }
 
@@ -30,7 +30,7 @@ body {
         border-bottom-right-radius: $borderRadius;
 
         .ui-icon-triangle-1-s {
-          @include icon_override ("\e930");
+          @include icon-override ("\e930");
         }
       }
     }

--- a/theme-base/components/menu/_breadcrumb.scss
+++ b/theme-base/components/menu/_breadcrumb.scss
@@ -25,7 +25,7 @@ body {
       }
 
       &.ui-breadcrumb-chevron {
-        @include icon_override("\e901");
+        @include icon-override("\e901");
         margin: 0 $inlineSpacing 0 $inlineSpacing;
         color: $breadcrumbSeparatorColor;
       }
@@ -45,7 +45,7 @@ body {
         }
 
         a.ui-icon-home {
-          @include icon_override("\e925");
+          @include icon-override("\e925");
           color: $breadcrumbItemIconColor;
           margin: 0;
 

--- a/theme-base/components/menu/_menu.scss
+++ b/theme-base/components/menu/_menu.scss
@@ -19,11 +19,11 @@ body {
           }
 
           .ui-icon-triangle-1-e {
-            @include icon_override("\e901");
+            @include icon-override("\e901");
           }
 
           .ui-icon-triangle-1-s {
-            @include icon_override("\e902");
+            @include icon-override("\e902");
           }
 
           h3 {
@@ -106,14 +106,14 @@ body {
           }
 
           .ui-icon-triangle-1-e:last-child {
-            @include icon_override("\e932");
+            @include icon-override("\e932");
             position: relative;
             margin-right: math.div(-1 * $iconSize, 2);
             color: $menuitemIconColor;
           }
 
           .ui-icon-triangle-1-s:last-child {
-            @include icon_override("\e930");
+            @include icon-override("\e930");
             margin-right: math.div(-1 * $iconSize, 2);
             color: $menuitemIconColor;
           }
@@ -215,7 +215,7 @@ body {
         .ui-icon-triangle-1-w {
           position: relative;
           top: 2px;
-          @include icon_override("\e931");
+          @include icon-override("\e931");
           margin-right: $inlineSpacing;
         }
       }

--- a/theme-base/components/menu/_panelmenu.scss
+++ b/theme-base/components/menu/_panelmenu.scss
@@ -46,11 +46,11 @@ body {
         margin-right: $inlineSpacing;
 
         &.ui-icon-triangle-1-e {
-          @include icon_override("\e901");
+          @include icon-override("\e901");
         }
 
         &.ui-icon-triangle-1-s {
-          @include icon_override("\e902");
+          @include icon-override("\e902");
         }
       }
 
@@ -116,11 +116,11 @@ body {
 
           &.ui-panelmenu-icon {
             &.ui-icon-triangle-1-e {
-              @include icon_override("\e932");
+              @include icon-override("\e932");
             }
 
             &.ui-icon-triangle-1-s {
-              @include icon_override("\e930");
+              @include icon-override("\e930");
             }
           }
         }

--- a/theme-base/components/messages/_growl.scss
+++ b/theme-base/components/messages/_growl.scss
@@ -8,7 +8,7 @@ body {
       box-shadow: $overlayContainerShadow;
 
       .ui-icon-closethick {
-        @include icon_override("\e90b");
+        @include icon-override("\e90b");
         position: absolute;
         top: .5rem;
         right: .5rem;
@@ -26,7 +26,7 @@ body {
         border-width: $messagesBorderWidth;
 
         .ui-growl-image {
-          @include icon_override("\e924");
+          @include icon-override("\e924");
           font-size: $growlIconFontSize;
           color: $infoMessageIconColor;
         }
@@ -43,7 +43,7 @@ body {
         border-width: $messagesBorderWidth;
 
         .ui-growl-image {
-          @include icon_override("\e922");
+          @include icon-override("\e922");
           font-size: $growlIconFontSize;
           color: $warnMessageIconColor;
         }
@@ -60,7 +60,7 @@ body {
         border-width: $messagesBorderWidth;
 
         .ui-growl-image {
-          @include icon_override("\e90c");
+          @include icon-override("\e90c");
           font-size: $growlIconFontSize;
           color: $errorMessageIconColor;
         }

--- a/theme-base/components/messages/_message.scss
+++ b/theme-base/components/messages/_message.scss
@@ -11,7 +11,7 @@ body {
       color: $infoMessageTextColor;
 
       .ui-message-info-icon {
-        @include icon_override("\e924");
+        @include icon-override("\e924");
         margin: 0;
         color: $infoMessageIconColor;
         float: none;
@@ -33,7 +33,7 @@ body {
       color: $warnMessageTextColor;
 
       .ui-message-warn-icon {
-        @include icon_override("\e922");
+        @include icon-override("\e922");
         margin: 0;
         color: $warnMessageIconColor;
         float: none;
@@ -55,7 +55,7 @@ body {
       color: $errorMessageTextColor;
 
       .ui-message-error-icon {
-        @include icon_override("\e90c");
+        @include icon-override("\e90c");
         margin: 0;
         color: $errorMessageIconColor;
         float: none;

--- a/theme-base/components/messages/_messages.scss
+++ b/theme-base/components/messages/_messages.scss
@@ -40,7 +40,7 @@ body {
       transition: background-color $transitionDuration;
 
       .ui-icon-close {
-        @include icon_override("\e90b");
+        @include icon-override("\e90b");
       }
     }
 
@@ -51,7 +51,7 @@ body {
       color: $infoMessageTextColor;
 
       .ui-messages-info-icon {
-        @include icon_override("\e924");
+        @include icon-override("\e924");
         font-size: $messagesIconFontSize;
         margin: 0 $inlineSpacing 0 0;
         color: $infoMessageIconColor;
@@ -74,7 +74,7 @@ body {
       color: $warnMessageTextColor;
 
       .ui-messages-warn-icon {
-        @include icon_override("\e922");
+        @include icon-override("\e922");
         font-size: $messagesIconFontSize;
         margin: 0 $inlineSpacing 0 0;
         color: $warnMessageIconColor;
@@ -98,7 +98,7 @@ body {
 
       .ui-messages-error-icon,
       .ui-messages-fatal {
-        @include icon_override("\e90c");
+        @include icon-override("\e90c");
         font-size: $messagesIconFontSize;
         margin: 0 $inlineSpacing 0 0;
         color: $errorMessageIconColor;

--- a/theme-base/components/misc/_galleria.scss
+++ b/theme-base/components/misc/_galleria.scss
@@ -29,12 +29,12 @@ body {
       margin: $galleriaItemNavigatorMargin;
 
       .ui-galleria-item-prev-icon {
-        @include icon_override("\e900");
+        @include icon-override("\e900");
         font-size: $galleriaItemNavigatorFontSize;
       }
 
       .ui-galleria-item-next-icon {
-        @include icon_override("\e901");
+        @include icon-override("\e901");
         font-size: $galleriaItemNavigatorFontSize;
       }
 
@@ -134,19 +134,19 @@ body {
         }
 
         .ui-icon-circle-triangle-e {
-          @include icon_override("\e901");
+          @include icon-override("\e901");
         }
 
         .ui-icon-circle-triangle-s {
-          @include icon_override("\e902");
+          @include icon-override("\e902");
         }
 
         .ui-icon-circle-triangle-w {
-          @include icon_override("\e900");
+          @include icon-override("\e900");
         }
 
         .ui-icon-circle-triangle-n {
-          @include icon_override("\e903");
+          @include icon-override("\e903");
         }
       }
 

--- a/theme-base/components/misc/_log.scss
+++ b/theme-base/components/misc/_log.scss
@@ -22,27 +22,27 @@ body {
         @include action-icon();
 
         .ui-icon-trash {
-          @include icon_override("\e93d");
+          @include icon-override("\e93d");
         }
 
         .ui-icon-note {
-          @include icon_override("\e9a8");
+          @include icon-override("\e9a8");
         }
 
         .ui-icon-info {
-          @include icon_override("\e924");
+          @include icon-override("\e924");
         }
 
         .ui-icon-notice {
-          @include icon_override("\e989");
+          @include icon-override("\e989");
         }
 
         .ui-icon-search {
-          @include icon_override("\e908");
+          @include icon-override("\e908");
         }
 
         .ui-icon-alert {
-          @include icon_override("\e922");
+          @include icon-override("\e922");
         }
       }
     }

--- a/theme-base/components/overlay/_dialog.scss
+++ b/theme-base/components/overlay/_dialog.scss
@@ -25,23 +25,23 @@ body {
         @include action-icon();
 
         .ui-icon-closethick {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
 
         .ui-icon-minus {
-          @include icon_override("\e90f");
+          @include icon-override("\e90f");
         }
 
         .ui-icon-plus {
-          @include icon_override("\e90d");
+          @include icon-override("\e90d");
         }
 
         .ui-icon-extlink {
-          @include icon_override("\e93b");
+          @include icon-override("\e93b");
         }
 
         .ui-icon-newwin {
-          @include icon_override("\e93a");
+          @include icon-override("\e93a");
         }
       }
     }
@@ -86,15 +86,15 @@ body {
             font-size: $confirmDialogIconFontSize;
 
             &.ui-icon-warn {
-              @include icon_override("\e922");
+              @include icon-override("\e922");
             }
 
             &.ui-icon-info {
-              @include icon_override("\e924");
+              @include icon-override("\e924");
             }
 
             &.ui-icon-error {
-              @include icon_override("\e90c");
+              @include icon-override("\e90c");
             }
           }
         }
@@ -127,19 +127,19 @@ body {
             height: auto;
 
             &.ui-messages-warn-icon {
-              @include icon_override("\e922");
+              @include icon-override("\e922");
             }
 
             &.ui-messages-info-icon {
-              @include icon_override("\e924");
+              @include icon-override("\e924");
             }
 
             &.ui-messages-error-icon {
-              @include icon_override("\e90c");
+              @include icon-override("\e90c");
             }
 
             &.ui-messages-fatal-icon {
-              @include icon_override("\e910");
+              @include icon-override("\e910");
             }
           }
         }

--- a/theme-base/components/overlay/_lightbox.scss
+++ b/theme-base/components/overlay/_lightbox.scss
@@ -19,7 +19,7 @@ body {
         @include action-icon();
 
         .ui-icon {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
       }
     }
@@ -32,7 +32,7 @@ body {
       padding: 0;
 
       .ui-lightbox-nav-left {
-        @include icon_override("\e900");
+        @include icon-override("\e900");
         transition: all $transitionDuration;
         font-size: 24px;
         margin-left: 4px;
@@ -48,7 +48,7 @@ body {
       }
 
       .ui-lightbox-nav-right {
-        @include icon_override("\e901");
+        @include icon-override("\e901");
         transition: all $transitionDuration;
         font-size: 24px;
         margin-right: 4px;

--- a/theme-base/components/overlay/_overlaypanel.scss
+++ b/theme-base/components/overlay/_overlaypanel.scss
@@ -31,7 +31,7 @@ body {
       }
 
       .ui-icon {
-        @include icon_override("\e90b");
+        @include icon-override("\e90b");
         display: inline-block;
         line-height: inherit;
       }

--- a/theme-base/components/overlay/_sidebar.scss
+++ b/theme-base/components/overlay/_sidebar.scss
@@ -11,7 +11,7 @@ body {
       @include action-icon();
 
       .ui-icon {
-        @include icon_override("\e90b");
+        @include icon-override("\e90b");
       }
     }
 

--- a/theme-base/components/panel/_accordion.scss
+++ b/theme-base/components/panel/_accordion.scss
@@ -75,11 +75,11 @@ body {
         margin: 0 $inlineSpacing 0 0;
 
         &.ui-icon-triangle-1-e {
-          @include icon_override("\e901");
+          @include icon-override("\e901");
         }
 
         &.ui-icon-triangle-1-s {
-          @include icon_override("\e902");
+          @include icon-override("\e902");
         }
       }
 
@@ -90,19 +90,19 @@ body {
         margin-bottom: math.div(-1 * $actionIconHeight, 4);
 
         .ui-icon-closethick {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
 
         .ui-icon-minusthick {
-          @include icon_override("\e90f");
+          @include icon-override("\e90f");
         }
 
         .ui-icon-plusthick {
-          @include icon_override("\e90d");
+          @include icon-override("\e90d");
         }
 
         .ui-icon-gear {
-          @include icon_override("\e94a");
+          @include icon-override("\e94a");
         }
       }
     }

--- a/theme-base/components/panel/_fieldset.scss
+++ b/theme-base/components/panel/_fieldset.scss
@@ -23,11 +23,11 @@ body {
       }
 
       .ui-icon-minusthick {
-        @include icon_override("\e90f");
+        @include icon-override("\e90f");
       }
 
       .ui-icon-plusthick {
-        @include icon_override("\e90d");
+        @include icon-override("\e90d");
       }
 
       &.ui-state-hover {

--- a/theme-base/components/panel/_panel.scss
+++ b/theme-base/components/panel/_panel.scss
@@ -23,19 +23,19 @@ body {
         margin-bottom: math.div(-1 * $actionIconHeight, 4);
 
         .ui-icon-closethick {
-          @include icon_override("\e90b");
+          @include icon-override("\e90b");
         }
 
         .ui-icon-minusthick {
-          @include icon_override("\e90f");
+          @include icon-override("\e90f");
         }
 
         .ui-icon-plusthick {
-          @include icon_override("\e90d");
+          @include icon-override("\e90d");
         }
 
         .ui-icon-gear {
-          @include icon_override("\e94a");
+          @include icon-override("\e94a");
         }
       }
 

--- a/theme-base/components/panel/_tabs.scss
+++ b/theme-base/components/panel/_tabs.scss
@@ -40,7 +40,7 @@ body {
             &.ui-icon-close {
               margin: 0;
               float: none;
-              @include icon_override("\e90b");
+              @include icon-override("\e90b");
               margin-left: $inlineSpacing;
             }
           }
@@ -284,7 +284,7 @@ body {
 
           .ui-icon {
             margin: 0;
-            @include icon_override("\e900");
+            @include icon-override("\e900");
           }
         }
 
@@ -294,7 +294,7 @@ body {
 
           .ui-icon {
             margin: 0;
-            @include icon_override("\e901");
+            @include icon-override("\e901");
           }
         }
 

--- a/theme-base/components/panel/_wizard.scss
+++ b/theme-base/components/panel/_wizard.scss
@@ -31,7 +31,7 @@ body {
     }
 
     .ui-icon-arrowthick-1-e {
-      @include icon_override('\e91b');
+      @include icon-override('\e91b');
     }
 
   }


### PR DESCRIPTION
Found this fun fact so I thought i would make our SASS all consistent and use dashes.

https://sass-lang.com/documentation/at-rules/mixin

![image](https://github.com/primefaces/primefaces-sass-theme/assets/4399574/a205cb91-ed7a-427b-a464-8a1c953f09d4)
