### PR TITLE
ProgressBar: add severities support

### DIFF
--- a/theme-base/components/misc/_progressbar.scss
+++ b/theme-base/components/misc/_progressbar.scss
@@ -17,5 +17,29 @@ body {
       color: $textColor;
       line-height: $progressBarHeight;
     }
+
+    &.ui-progressbar-success {
+      .ui-progressbar-value {
+        background: $successButtonBg;
+      }
+    }
+
+    &.ui-progressbar-info {
+      .ui-progressbar-value {
+        background: $infoButtonBg;
+      }
+    }
+
+    &.ui-progressbar-warning {
+      .ui-progressbar-value {
+        background: $warningButtonBg;
+      }
+    }
+
+    &.ui-progressbar-danger {
+      .ui-progressbar-value {
+        background: $dangerButtonBg;
+      }
+    }
   }
 }


### PR DESCRIPTION
see [primefaces#11404](https://github.com/primefaces/primefaces/issues/11404)

Not sure what to do with the text color. From my experiments it's better not to use the buttons text color as they may hardly readable if the progressbar values is less than 50%